### PR TITLE
Remove redundant debug

### DIFF
--- a/src/main/java/io/github/revxrsal/eventbus/base/BaseEventBus.java
+++ b/src/main/java/io/github/revxrsal/eventbus/base/BaseEventBus.java
@@ -168,7 +168,6 @@ public abstract class BaseEventBus implements EventBus {
     @Override public <T> void registerListener(@NotNull EventListener<T> listener) {
         try {
             for (Type type : listener.getClass().getGenericInterfaces()) {
-                System.out.println(type);
                 if (type.getTypeName().startsWith(EventListener.class.getName())) {
                     Class eventType = type instanceof ParameterizedType ? (Class<?>) ((ParameterizedType) type).getActualTypeArguments()[0] : Object.class;
                     registerListener(eventType, listener);


### PR DESCRIPTION
Just removed System.out.println code that probably placed for debugging. 